### PR TITLE
correct handling of DMA buffers

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
@@ -95,6 +95,8 @@ void disp_spi_send_data(uint8_t * data, uint16_t length)
     spi_trans_in_progress = true;
     spi_color_sent = false;             //Mark the "lv_flush_ready" NOT needs to be called in "spi_ready"
     spi_device_queue_trans(spi, &t, portMAX_DELAY);
+	spi_transaction_t *ta = &t;
+    spi_device_get_trans_result(spi,&ta, portMAX_DELAY);
 
 }
 
@@ -112,6 +114,8 @@ void disp_spi_send_colors(uint8_t * data, uint16_t length)
     spi_trans_in_progress = true;
     spi_color_sent = true;              //Mark the "lv_flush_ready" needs to be called in "spi_ready"
     spi_device_queue_trans(spi, &t, portMAX_DELAY);
+	spi_transaction_t *ta = &t;
+    spi_device_get_trans_result(spi,&ta, portMAX_DELAY);
 }
 
 


### PR DESCRIPTION
spi_device_queue_trans implicitly allocates capable memory (DMA and 32bit aligned) if provided buffer in spi_transaction_t structure is not.
But only spi_device_get_trans_result sets this free again. So without calling spi_device_get_trans_result there is a memory leak stalling application after just a few calls to spi_device_queue_trans.