### PR TITLE
Allow TFT and Touch to share SPI bus

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.h
@@ -15,6 +15,7 @@ extern "C" {
  *********************/
 #include <stdint.h>
 #include <stdbool.h>
+#include <driver/spi_master.h>
 
 /*********************
  *      DEFINES
@@ -33,6 +34,8 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 void disp_spi_init(void);
+void disp_spi_add_device(spi_host_device_t host);
+void disp_spi_add_device_config(spi_host_device_t host, spi_device_interface_config_t *devcfg);
 void disp_spi_send_data(uint8_t * data, uint16_t length);
 void disp_spi_send_colors(uint8_t * data, uint16_t length);
 bool disp_spi_is_busy(void);

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.c
@@ -37,6 +37,27 @@ static spi_device_handle_t spi;
 /**********************
  *   GLOBAL FUNCTIONS
  **********************/
+void tp_spi_add_device_config(spi_host_device_t host, spi_device_interface_config_t *devcfg)
+{
+	esp_err_t ret=spi_bus_add_device(host, devcfg, &spi);
+	assert(ret==ESP_OK);
+}
+
+void tp_spi_add_device(spi_host_device_t host)
+{
+	spi_device_interface_config_t devcfg={
+		.clock_speed_hz=2*1000*1000,           //Clock out at 2 MHz
+		.mode=0,                               //SPI mode 0
+		.spics_io_num=TP_SPI_CS,               //CS pin
+		.queue_size=1,
+		.pre_cb=NULL,
+		.post_cb=NULL,
+	};
+	//Attach the LCD to the SPI bus
+	tp_spi_add_device_config(host, &devcfg);
+}
+
+
 void tp_spi_init(void)
 {
 
@@ -50,42 +71,29 @@ void tp_spi_init(void)
 		.quadhd_io_num=-1
 	};
 
-	spi_device_interface_config_t devcfg={
-		.clock_speed_hz=2*1000*1000,           //Clock out at 80 MHz
-		.mode=0,                                //SPI mode 0
-		.spics_io_num=-1,              //CS pin
-		.queue_size=1,
-		.pre_cb=NULL,
-		.post_cb=NULL,
-	};
-
 	//Initialize the SPI bus
 	ret=spi_bus_initialize(VSPI_HOST, &buscfg, 2);
 	assert(ret==ESP_OK);
 
 	//Attach the LCD to the SPI bus
-	ret=spi_bus_add_device(VSPI_HOST, &devcfg, &spi);
-	assert(ret==ESP_OK);
+	tp_spi_add_device(VSPI_HOST);
 }
 
-uint8_t tp_spi_xchg(uint8_t data_send)
+void tp_spi_xchg(uint8_t data_send[], uint8_t data_recv[], uint8_t byte_count)
 {
-    uint8_t data_recv = 0;
-    
-    spi_transaction_t t = {
-        .length = 8, // length is in bits
-        .tx_buffer = &data_send,
-        .rx_buffer = &data_recv
-    };
+	spi_transaction_t t = {
+		.length = byte_count * 8, // SPI transaction length is in bits
+		.tx_buffer = data_send,
+		.rx_buffer = data_recv};
 
-    spi_device_queue_trans(spi, &t, portMAX_DELAY);
+	esp_err_t ret = spi_device_queue_trans(spi, &t, portMAX_DELAY);
+	assert(ret == ESP_OK);
 
-    spi_transaction_t * rt;
-    spi_device_get_trans_result(spi, &rt, portMAX_DELAY);
-
-    return data_recv;
+	spi_transaction_t *rt;
+	ret = spi_device_get_trans_result(spi, &rt, portMAX_DELAY);
+	assert(ret == ESP_OK);
+	assert(&t == rt);
 }
-
 
 /**********************
  *   STATIC FUNCTIONS

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.h
@@ -14,6 +14,7 @@ extern "C" {
  *      INCLUDES
  *********************/
 #include <stdint.h>
+#include <driver/spi_master.h>
 
 /*********************
  *      DEFINES
@@ -35,7 +36,9 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 void tp_spi_init(void);
-uint8_t tp_spi_xchg(uint8_t data_send);
+void tp_spi_add_device(spi_host_device_t host);
+void tp_spi_add_device_config(spi_host_device_t host, spi_device_interface_config_t *config);
+void tp_spi_xchg(uint8_t data_send[], uint8_t data_recv[], uint8_t byte_count);
 
 /**********************
  *      MACROS

--- a/main/main.c
+++ b/main/main.c
@@ -28,9 +28,53 @@
 
 static void IRAM_ATTR lv_tick_task(void);
 
+#if CONFIG_LVGL_TOUCH_CONTROLLER == 1 && TP_SPI_MOSI == DISP_SPI_MOSI && TP_SPI_CLK == DISP_SPI_CLK
+static void configure_shared_spi_bus()
+{
+    spi_bus_config_t buscfg = {
+        .miso_io_num = TP_SPI_MISO,
+        .mosi_io_num = TP_SPI_MOSI,
+        .sclk_io_num = TP_SPI_CLK,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .max_transfer_sz = DISP_BUF_SIZE * 2,
+    };
+
+    esp_err_t ret = spi_bus_initialize(HSPI_HOST, &buscfg, 1);
+    assert(ret == ESP_OK);
+
+    spi_device_interface_config_t ili9341_config = {
+        .clock_speed_hz = 20 * 1000 * 1000,
+        .mode = 0,
+        .spics_io_num = DISP_SPI_CS,
+        .queue_size = 1,
+        .pre_cb = NULL,
+        .post_cb = NULL,
+    };
+
+    disp_spi_add_device_config(HSPI_HOST, &ili9341_config);
+    disp_driver_init();
+
+    spi_device_interface_config_t xpt2046_config = {
+        .clock_speed_hz = 2 * 1000 * 1000,
+        .mode = 0,
+        .spics_io_num = TP_SPI_CS,
+        .queue_size = 1,
+        .pre_cb = NULL,
+        .post_cb = NULL,
+    };
+
+    tp_spi_add_device_config(HSPI_HOST, &xpt2046_config);
+    xpt2046_init();
+}
+#endif
+
 void app_main() {
     lv_init();
 
+#if CONFIG_LVGL_TOUCH_CONTROLLER == 1 && TP_SPI_MOSI == DISP_SPI_MOSI && TP_SPI_CLK == DISP_SPI_CLK
+    configure_shared_spi_bus();
+#else
     disp_spi_init();
     disp_driver_init();
 
@@ -39,6 +83,7 @@ void app_main() {
     xpt2046_init();
 #elif CONFIG_LVGL_TOUCH_CONTROLLER == 2
     ft6x06_init(FT6236_I2C_SLAVE_ADDR);
+#endif
 #endif
 
     static lv_color_t buf1[DISP_BUF_SIZE];


### PR DESCRIPTION
This lets you configure the ILI9341 TFT display and the XPT2046 touch controller as devices on a shared SPI bus, freeing the other ESP32 SPI bus for other peripherals.

I didn't see #50 until just now, perhaps any changes that are being considered for that issue would eliminate the need for this pull request.

I tried to make a minimal set of changes that includes:

- Moving the configuration and handling of TP_SPI_CS to the esp-idf SPI layer so that it can be managed as part of the SPI transaction
- Reading the touch X and Y values in a single transaction
- Chaining to an optional user-supplied post_cb in disp_spi.c so that spi_ready can remain a private function
- Splitting the SPI bus and device configuration into a number of smaller functions to provide more options for initializing the bus and devices
- Updating main to initialize and configure the SPI bus if the definition of the MOSI and CLK GPIO pins indicates that they are shared

I think these last two items are the most relevant to #50.


