### PR TITLE
Fix #62, Show missing LVGL menu on menuconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ PROJECT_NAME := lvgl-demo
 # Add new components (source folders)
 # Must be before include $(IDF_PATH)/make/project.mk
 # $(PROJECT_PATH)/xxx didn't work -> use $(abspath xxx) instead
+EXTRA_COMPONENT_DIRS = components/lvgl_esp32_drivers/lvgl_tft
+EXTRA_COMPONENT_DIRS += components/lvgl_esp32_drivers/lvgl_touch
+EXTRA_COMPONENT_DIRS += components/lvgl
 
 include $(IDF_PATH)/make/project.mk
 


### PR DESCRIPTION
It now shows the missing menues @app-z

![fixed_lvgl_menuconfig](https://user-images.githubusercontent.com/11037705/75806362-1edcbd00-5d49-11ea-9f26-2e0659b6cfa5.PNG)
