### PR TITLE
created 'user friendly' driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set(EXTRA_COMPONENT_DIRS components/lvgl_esp32_drivers/lvgl_touch components/lvgl_esp32_drivers/lvgl_tft)
+set(EXTRA_COMPONENT_DIRS components/lvgl_esp32_drivers components/lvgl_esp32_drivers/lvgl_touch components/lvgl_esp32_drivers/lvgl_tft)
 project(lvgl-demo)

--- a/components/lv_examples/lv_ex_conf.h
+++ b/components/lv_examples/lv_ex_conf.h
@@ -42,7 +42,7 @@
 #define LV_USE_DEMO        1
 #if LV_USE_DEMO
 #define LV_DEMO_WALLPAPER  1    /*Create a wallpaper too*/
-#define LV_DEMO_SLIDE_SHOW 0    /*Automatically switch between tabs*/
+#define LV_DEMO_SLIDE_SHOW 1    /*Automatically switch between tabs*/
 #endif
 
 /*MCU and memory usage monitoring*/

--- a/components/lvgl_esp32_drivers/CMakeLists.txt
+++ b/components/lvgl_esp32_drivers/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB SOURCES *.c)
+
+idf_component_register(SRCS ${SOURCES}
+                       INCLUDE_DIRS .
+                       REQUIRES lvgl)

--- a/components/lvgl_esp32_drivers/component.mk
+++ b/components/lvgl_esp32_drivers/component.mk
@@ -1,0 +1,4 @@
+# LVGL esp32 drivers 
+
+COMPONENT_SRCDIRS := . 
+COMPONENT_ADD_INCLUDEDIRS := .

--- a/components/lvgl_esp32_drivers/lvgl_driver.c
+++ b/components/lvgl_esp32_drivers/lvgl_driver.c
@@ -23,7 +23,9 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+#ifdef SHARED_SPI_BUS
 static void configure_shared_spi_bus(void);
+#endif  // SHARED_SPI_BUS
 
 /**********************
  *  STATIC VARIABLES
@@ -60,6 +62,7 @@ void lvgl_driver_init(void)
 /**********************
  *   STATIC FUNCTIONS
  **********************/
+#ifdef SHARED_SPI_BUS
 static void configure_shared_spi_bus(void)
 {
 	/* Shared SPI bus configuration */
@@ -87,3 +90,4 @@ static void configure_shared_spi_bus(void)
 	disp_spi_add_device(TFT_SPI_HOST);
 	tp_spi_add_device(TOUCH_SPI_HOST);
 }
+#endif  // SHARED_SPI_BUS

--- a/components/lvgl_esp32_drivers/lvgl_driver.c
+++ b/components/lvgl_esp32_drivers/lvgl_driver.c
@@ -23,6 +23,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
+static void configure_shared_spi_bus(void);
 
 /**********************
  *  STATIC VARIABLES
@@ -56,7 +57,10 @@ void lvgl_driver_init(void)
 #endif  // SHARED_SPI_BUS
 }
 
-void configure_shared_spi_bus(void)
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+static void configure_shared_spi_bus(void)
 {
 	/* Shared SPI bus configuration */
 	spi_bus_config_t buscfg = {
@@ -83,8 +87,3 @@ void configure_shared_spi_bus(void)
 	disp_spi_add_device(TFT_SPI_HOST);
 	tp_spi_add_device(TOUCH_SPI_HOST);
 }
-
-
-/**********************
- *   STATIC FUNCTIONS
- **********************/

--- a/components/lvgl_esp32_drivers/lvgl_driver.c
+++ b/components/lvgl_esp32_drivers/lvgl_driver.c
@@ -1,0 +1,90 @@
+/**
+ * @file lvgl_driver.c
+ *
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "sdkconfig.h"
+#include "lvgl_driver.h"
+
+#include "lvgl_tft/disp_spi.h"
+#include "lvgl_touch/tp_spi.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+void lvgl_driver_init(void)
+{
+    /* Interface and driver initialization */
+#ifdef SHARED_SPI_BUS
+	/* Configure one SPI bus for the two devices */
+	configure_shared_spi_bus();
+    
+	/* Configure the drivers */
+	disp_driver_init(false);
+#if CONFIG_LVGL_TOUCH_CONTROLLER != TOUCH_CONTROLLER_NONE
+	touch_driver_init(false);
+#endif
+#else
+	/* Otherwise configure the SPI bus and devices separately inside the drivers*/
+	disp_driver_init(true);
+#if CONFIG_LVGL_TOUCH_CONTROLLER != TOUCH_CONTROLLER_NONE
+	touch_driver_init(true);
+#endif
+#endif  // SHARED_SPI_BUS
+}
+
+void configure_shared_spi_bus(void)
+{
+	/* Shared SPI bus configuration */
+	spi_bus_config_t buscfg = {
+		.miso_io_num = TP_SPI_MISO,
+		.mosi_io_num = DISP_SPI_MOSI,
+		.sclk_io_num = DISP_SPI_CLK,
+		.quadwp_io_num = -1,
+		.quadhd_io_num = -1,
+#if CONFIG_LVGL_TFT_DISPLAY_CONTROLLER == TFT_CONTROLLER_ILI9341
+		.max_transfer_sz = DISP_BUF_SIZE * 2,
+#elif CONFIG_LVGL_TFT_DISPLAY_CONTROLLER == TFT_CONTROLLER_ST7789
+		.max_transfer_sz = DISP_BUF_SIZE * 2,
+#elif CONFIG_LVGL_TFT_DISPLAY_CONTROLLER == TFT_CONTROLLER_ILI9488
+		.max_transfer_sz = DISP_BUF_SIZE * 3,
+#elif CONFIG_LVGL_TFT_DISPLAY_CONTROLLER == TFT_CONTROLLER_HX8357
+		.max_transfer_sz = DISP_BUF_SIZE * 2
+#endif
+	};
+
+	esp_err_t ret = spi_bus_initialize(TFT_SPI_HOST, &buscfg, 1);
+	assert(ret == ESP_OK);
+
+	/* SPI Devices */
+	disp_spi_add_device(TFT_SPI_HOST);
+	tp_spi_add_device(TOUCH_SPI_HOST);
+}
+
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/

--- a/components/lvgl_esp32_drivers/lvgl_driver.h
+++ b/components/lvgl_esp32_drivers/lvgl_driver.h
@@ -30,8 +30,6 @@ extern "C" {
  * GLOBAL PROTOTYPES
  **********************/
 void lvgl_driver_init(void);
-void configure_shared_spi_bus(void);
-
 
 /**********************
  *      MACROS

--- a/components/lvgl_esp32_drivers/lvgl_driver.h
+++ b/components/lvgl_esp32_drivers/lvgl_driver.h
@@ -1,0 +1,45 @@
+/**
+ * @file lvgl_driver.h
+ *
+ */
+
+#ifndef LVGL_DRIVER_H
+#define LVGL_DRIVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "lvgl_spi_conf.h"
+#include "lvgl_tft/disp_driver.h"
+#include "lvgl_touch/touch_driver.h"
+
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+void lvgl_driver_init(void);
+void configure_shared_spi_bus(void);
+
+
+/**********************
+ *      MACROS
+ **********************/
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /*LVGL_DRIVER_H*/

--- a/components/lvgl_esp32_drivers/lvgl_spi_conf.h
+++ b/components/lvgl_esp32_drivers/lvgl_spi_conf.h
@@ -45,7 +45,7 @@ extern "C" {
 // Detect the use of a shared SPI Bus and verify the user specified the same SPI bus for both touch and tft
 #if (CONFIG_LVGL_TOUCH_CONTROLLER == 1 || CONFIG_LVGL_TOUCH_CONTROLLER == 3) && TP_SPI_MOSI == DISP_SPI_MOSI && TP_SPI_CLK == DISP_SPI_CLK
 #if TFT_SPI_HOST != TOUCH_SPI_HOST
-#error You must specifiy the same SPI host for both display and input driver
+#error You must specify the same SPI host (HSPI or VSPI) for both display and touch driver
 #endif
 
 #define SHARED_SPI_BUS

--- a/components/lvgl_esp32_drivers/lvgl_spi_conf.h
+++ b/components/lvgl_esp32_drivers/lvgl_spi_conf.h
@@ -1,0 +1,72 @@
+/**
+ * @file lvgl_spi_conf.h
+ *
+ */
+
+#ifndef LVGL_SPI_CONF_H
+#define LVGL_SPI_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+/*********************
+ *      DEFINES
+ *********************/
+// DISPLAY PINS
+#define DISP_SPI_MOSI CONFIG_LVGL_DISP_SPI_MOSI
+#define DISP_SPI_CLK CONFIG_LVGL_DISP_SPI_CLK
+#define DISP_SPI_CS CONFIG_LVGL_DISP_SPI_CS
+
+// TOUCHPAD PINS
+#define TP_SPI_MOSI CONFIG_LVGL_TOUCH_SPI_MOSI
+#define TP_SPI_MISO CONFIG_LVGL_TOUCH_SPI_MISO
+#define TP_SPI_CLK  CONFIG_LVGL_TOUCH_SPI_CLK
+#define TP_SPI_CS   CONFIG_LVGL_TOUCH_SPI_CS
+
+#define ENABLE_TOUCH_INPUT  CONFIG_LVGL_ENABLE_TOUCH
+
+#if CONFIG_LVGL_TFT_DISPLAY_SPI_HSPI == 1
+#define TFT_SPI_HOST HSPI_HOST
+#else
+#define TFT_SPI_HOST VSPI_HOST
+#endif /*CONFIG_LVGL_TFT_DISPLAY_SPI_HSPI == 1*/
+
+#if CONFIG_LVGL_TOUCH_CONTROLLER_SPI_HSPI == 1
+#define TOUCH_SPI_HOST HSPI_HOST
+#else
+#define TOUCH_SPI_HOST VSPI_HOST
+#endif /*CONFIG_LVGL_TOUCH_CONTROLLER_SPI_HSPI == 1*/
+
+// Detect the use of a shared SPI Bus and verify the user specified the same SPI bus for both touch and tft
+#if (CONFIG_LVGL_TOUCH_CONTROLLER == 1 || CONFIG_LVGL_TOUCH_CONTROLLER == 3) && TP_SPI_MOSI == DISP_SPI_MOSI && TP_SPI_CLK == DISP_SPI_CLK
+#if TFT_SPI_HOST != TOUCH_SPI_HOST
+#error You must specifiy the same SPI host for both display and input driver
+#endif
+
+#define SHARED_SPI_BUS
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+
+/**********************
+ *      MACROS
+ **********************/
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /*LVGL_SPI_CONF_H*/

--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.c
@@ -21,6 +21,8 @@
 #include "disp_spi.h"
 #include "disp_driver.h"
 
+#include "../lvgl_driver.h"
+
 /*********************
  *      DEFINES
  *********************/

--- a/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.h
+++ b/components/lvgl_esp32_drivers/lvgl_tft/disp_spi.h
@@ -21,11 +21,6 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#define DISP_SPI_MOSI CONFIG_LVGL_DISP_SPI_MOSI
-#define DISP_SPI_CLK CONFIG_LVGL_DISP_SPI_CLK
-#define DISP_SPI_CS CONFIG_LVGL_DISP_SPI_CS
-
-
 /**********************
  *      TYPEDEFS
  **********************/

--- a/components/lvgl_esp32_drivers/lvgl_touch/touch_driver.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/touch_driver.c
@@ -14,7 +14,7 @@ void touch_driver_init(bool init_spi)
     }
     xpt2046_init();
 #elif CONFIG_LVGL_TOUCH_CONTROLLER == TOUCH_CONTROLLER_FT6X06
-    ft6x36_init(FT6236_I2C_SLAVE_ADDR);
+    ft6x06_init(FT6236_I2C_SLAVE_ADDR);
 #elif CONFIG_LVGL_TOUCH_CONTROLLER == TOUCH_CONTROLLER_STMPE610
 	if (init_spi) {
     	tp_spi_init();

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.c
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.c
@@ -13,6 +13,8 @@
 #include "driver/spi_master.h"
 #include <string.h>
 
+#include "../lvgl_driver.h"
+
 /*********************
  *      DEFINES
  *********************/

--- a/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.h
+++ b/components/lvgl_esp32_drivers/lvgl_touch/tp_spi.h
@@ -20,14 +20,6 @@ extern "C" {
  *      DEFINES
  *********************/
 
-#define ENABLE_TOUCH_INPUT  CONFIG_LVGL_ENABLE_TOUCH
-
-#define TP_SPI_MOSI CONFIG_LVGL_TOUCH_SPI_MOSI
-#define TP_SPI_MISO CONFIG_LVGL_TOUCH_SPI_MISO
-#define TP_SPI_CLK  CONFIG_LVGL_TOUCH_SPI_CLK
-#define TP_SPI_CS   CONFIG_LVGL_TOUCH_SPI_CS
-
-
 /**********************
  *      TYPEDEFS
  **********************/

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(SOURCES main.c)
 idf_component_register(SRCS ${SOURCES}
                     INCLUDE_DIRS .
-                    REQUIRES lvgl_touch lvgl_tft lvgl lv_examples)
+                    REQUIRES lvgl_esp32_drivers lvgl_touch lvgl_tft lvgl lv_examples)
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE LV_CONF_INCLUDE_SIMPLE=1)


### PR DESCRIPTION
Idea is to create a 'user friendly' driver meaning that `main.c` would look something like this:
```
...
#include "lvgl/lvgl.h"
#include "lvgl_driver.h"
...
void app_main() {
    lv_init();
    lvgl_driver_init();
...
}
```
I don't know if i configured `CMakeLists.txt` and `component.mk` correctly, but the demo program works (tested on ILI9341 and XPT2046 with shared SPI).
Probably the file/function names are not really the best, but this is only a suggestion...
