### PR TITLE
More complete example working with different peripherals

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ idf_component_register(SRCS ${SOURCES}
 
 target_compile_definitions(${COMPONENT_LIB PRIVATE LV_CONF_INCLUDE_SIMPLE=1)
 ```
+Please, note that if your project require the use of the `nvs_flash` module, it should be put in the `REQUIRES` list.
 
 #### Makefile
 If you are using make, you only need to add the EXTRA_COMPONENT_DIRS in the root Makefile of your project:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ idf_component_register(SRCS ${SOURCES}
 
 target_compile_definitions(${COMPONENT_LIB PRIVATE LV_CONF_INCLUDE_SIMPLE=1)
 ```
-Please, note that if your project require the use of the `nvs_flash` module, it should be put in the `REQUIRES` list.
+Please note that if your project require the use of the `nvs_flash` module \(for example required by WiFi\), it should be put in the `REQUIRES` list.
 
 #### Makefile
 If you are using make, you only need to add the EXTRA_COMPONENT_DIRS in the root Makefile of your project:

--- a/main/main.c
+++ b/main/main.c
@@ -45,11 +45,11 @@ void app_main() {
     
     //If you want to use a task to create the graphic, you NEED to create a Pinned task
     //Otherwise there can be problem such as memory corruption and so on
-	xTaskCreatePinnedToCore(guiTask, "gui", 4096*2, NULL, 0, NULL, 1);
+    xTaskCreatePinnedToCore(guiTask, "gui", 4096*2, NULL, 0, NULL, 1);
 }
 
 static void IRAM_ATTR lv_tick_task(void) {
-	lv_tick_inc(portTICK_RATE_MS);
+    lv_tick_inc(portTICK_RATE_MS);
 }
 
 //Creates a semaphore to handle concurrent call to lvgl stuff
@@ -83,7 +83,7 @@ void guiTask() {
     lv_indev_drv_register(&indev_drv);
 #endif
 
-	const esp_timer_create_args_t periodic_timer_args = {
+    const esp_timer_create_args_t periodic_timer_args = {
             .callback = &lv_tick_task,
             /* name is optional, but may help identify the timer when debugging */
             .name = "periodic_gui"
@@ -91,7 +91,7 @@ void guiTask() {
     esp_timer_handle_t periodic_timer;
     ESP_ERROR_CHECK(esp_timer_create(&periodic_timer_args, &periodic_timer));
     //On ESP32 it's better to create a periodic task instead of esp_register_freertos_tick_hook
-	ESP_ERROR_CHECK(esp_timer_start_periodic(periodic_timer, 10*1000)); //10ms (expressed as microseconds)
+    ESP_ERROR_CHECK(esp_timer_start_periodic(periodic_timer, 10*1000)); //10ms (expressed as microseconds)
 
     demo_create();
 

--- a/main/main.c
+++ b/main/main.c
@@ -16,6 +16,8 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_freertos_hooks.h"
+#include "freertos/semphr.h"
+
 
 #include "esp_system.h"
 #include "driver/gpio.h"
@@ -33,6 +35,7 @@
  *  STATIC PROTOTYPES
  **********************/
 static void IRAM_ATTR lv_tick_task(void);
+void guiTask();
 
 
 /**********************

--- a/main/main.c
+++ b/main/main.c
@@ -39,39 +39,68 @@ static void IRAM_ATTR lv_tick_task(void);
  *   APPLICATION MAIN
  **********************/
 void app_main() {
-	lv_init();
-
-    lvgl_driver_init();
-
-	static lv_color_t buf1[DISP_BUF_SIZE];
-	static lv_color_t buf2[DISP_BUF_SIZE];
-	static lv_disp_buf_t disp_buf;
-	lv_disp_buf_init(&disp_buf, buf1, buf2, DISP_BUF_SIZE);
-
-	lv_disp_drv_t disp_drv;
-	lv_disp_drv_init(&disp_drv);
-	disp_drv.flush_cb = disp_driver_flush;
-	disp_drv.buffer = &disp_buf;
-	lv_disp_drv_register(&disp_drv);
-
-#if CONFIG_LVGL_TOUCH_CONTROLLER != TOUCH_CONTROLLER_NONE
-	lv_indev_drv_t indev_drv;
-	lv_indev_drv_init(&indev_drv);
-	indev_drv.read_cb = touch_driver_read;
-	indev_drv.type = LV_INDEV_TYPE_POINTER;
-	lv_indev_drv_register(&indev_drv);
-#endif
-
-	esp_register_freertos_tick_hook(lv_tick_task);
-
-	demo_create();
-
-	while (1) {
-		vTaskDelay(1);
-		lv_task_handler();
-	}
+    
+    //If you want to use a task to create the graphic, you NEED to create a Pinned task
+    //Otherwise there can be problem such as memory corruption and so on
+	xTaskCreatePinnedToCore(guiTask, "gui", 4096*2, NULL, 0, NULL, 1);
 }
 
 static void IRAM_ATTR lv_tick_task(void) {
 	lv_tick_inc(portTICK_RATE_MS);
+}
+
+//Creates a semaphore to handle concurrent call to lvgl stuff
+//If you wish to call *any* lvgl function from other threads/tasks
+//you should lock on the very same semaphore!
+SemaphoreHandle_t xGuiSemaphore;
+
+void guiTask() {
+    xGuiSemaphore = xSemaphoreCreateMutex();
+
+    lv_init();
+
+    lvgl_driver_init();
+
+    static lv_color_t buf1[DISP_BUF_SIZE];
+    static lv_color_t buf2[DISP_BUF_SIZE];
+    static lv_disp_buf_t disp_buf;
+    lv_disp_buf_init(&disp_buf, buf1, buf2, DISP_BUF_SIZE);
+
+    lv_disp_drv_t disp_drv;
+    lv_disp_drv_init(&disp_drv);
+    disp_drv.flush_cb = disp_driver_flush;
+    disp_drv.buffer = &disp_buf;
+    lv_disp_drv_register(&disp_drv);
+
+#if CONFIG_LVGL_TOUCH_CONTROLLER != TOUCH_CONTROLLER_NONE
+    lv_indev_drv_t indev_drv;
+    lv_indev_drv_init(&indev_drv);
+    indev_drv.read_cb = touch_driver_read;
+    indev_drv.type = LV_INDEV_TYPE_POINTER;
+    lv_indev_drv_register(&indev_drv);
+#endif
+
+	const esp_timer_create_args_t periodic_timer_args = {
+            .callback = &lv_tick_task,
+            /* name is optional, but may help identify the timer when debugging */
+            .name = "periodic_gui"
+    };
+    esp_timer_handle_t periodic_timer;
+    ESP_ERROR_CHECK(esp_timer_create(&periodic_timer_args, &periodic_timer));
+    //On ESP32 it's better to create a periodic task instead of esp_register_freertos_tick_hook
+	ESP_ERROR_CHECK(esp_timer_start_periodic(periodic_timer, 10*1000)); //10ms (expressed as microseconds)
+
+    demo_create();
+
+    while (1) {
+        vTaskDelay(1);
+        //Try to lock the semaphore, if success, call lvgl stuff
+        if (xSemaphoreTake(xGuiSemaphore, (TickType_t)10) == pdTRUE) {
+            lv_task_handler();
+            xSemaphoreGive(xGuiSemaphore);
+        }
+    }
+
+    //A task should NEVER return
+    vTaskDelete(NULL);
 }


### PR DESCRIPTION
The example has been rewrote to use tasks.
I spent almost a night trying to understand a memory corruption, but this seems to work pretty well.
Tested successfully with high memory and CPU usage, high network traffic and concurrent i2s communication.
It pins the `guiTask` to only one core in order to prevent problem with SPI communication.
Uses `esp_timer_start_periodic` to call `lv_tick_task` periodically.
Uses Semaphores to show how to synchronize with different other tasks.
