### PR TITLE
Restore option to choose spi bus on display controller menu

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
@@ -156,7 +156,7 @@ menu "LittlevGL (LVGL) TFT Display controller"
 	endchoice
 
     choice
-        prompt "TFT SPI Bus."
+        prompt "TFT SPI Bus." if LVGL_TFT_DISPLAY_PROTOCOL_SPI
     	  default LVGL_TFT_DISPLAY_SPI_HSPI
     	  help
     	      Select the SPI Bus the TFT Display is attached to.

--- a/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
+++ b/components/lvgl_esp32_drivers/lvgl_tft/Kconfig
@@ -156,7 +156,7 @@ menu "LittlevGL (LVGL) TFT Display controller"
 	endchoice
 
     choice
-        prompt "TFT SPI Bus." if LVGL_PREDEFINED_DISPLAY_M5STACK || LVGL_PREDEFINED_DISPLAY_M5STICK
+        prompt "TFT SPI Bus."
     	  default LVGL_TFT_DISPLAY_SPI_HSPI
     	  help
     	      Select the SPI Bus the TFT Display is attached to.


### PR DESCRIPTION
@an-erd This option was changed on #94 , any particular reason?
Had to remove what you added to fix #96 