### PR TITLE
ILI9488: Fix low DMA crash - retry on allocation failure

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9488.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9488.c
@@ -121,10 +121,11 @@ void ili9488_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
     uint32_t size = lv_area_get_width(area) * lv_area_get_height(area);
 
     lv_color16_t *buffer_16bit = (lv_color16_t *) color_map;
-    uint8_t *mybuf = (uint8_t *) heap_caps_malloc(3 * size * sizeof(uint8_t), MALLOC_CAP_DMA);
-    while (mybuf == NULL) {
+    uint8_t *mybuf;
+    do {
         mybuf = (uint8_t *) heap_caps_malloc(3 * size * sizeof(uint8_t), MALLOC_CAP_DMA);
-    }
+        if (mybuf == NULL)  ESP_LOGW(TAG, "Could not allocate enough DMA memory!");
+    } while (mybuf == NULL);
 
     uint32_t LD = 0;
     uint32_t j = 0;

--- a/components/lvgl_esp32_drivers/lvgl_tft/ili9488.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/ili9488.c
@@ -122,6 +122,9 @@ void ili9488_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
 
     lv_color16_t *buffer_16bit = (lv_color16_t *) color_map;
     uint8_t *mybuf = (uint8_t *) heap_caps_malloc(3 * size * sizeof(uint8_t), MALLOC_CAP_DMA);
+    while (mybuf == NULL) {
+        mybuf = (uint8_t *) heap_caps_malloc(3 * size * sizeof(uint8_t), MALLOC_CAP_DMA);
+    }
 
     uint32_t LD = 0;
     uint32_t j = 0;
@@ -164,7 +167,7 @@ void ili9488_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
 	ili9488_send_cmd(ILI9488_CMD_MEMORY_WRITE);
 
 	ili9488_send_color((void *) mybuf, size * 3);
-        heap_caps_free(mybuf);
+	heap_caps_free(mybuf);
 }
 
 void ili9488_enable_backlight(bool backlight)


### PR DESCRIPTION
In case of high DMA usage, the driver may not be able to allocate enough DMA capable memory resulting in a crash. Retry loop till enough memory becomes available.

Example of high DMA usage: High rate of HTTP requests & responses (>2048 bytes) via WiFi while updating big portions of the screen.